### PR TITLE
add missing terraform variables for appinsights

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -30,3 +30,16 @@ variable "team_name" {
 variable "team_contact" {
   default = "#cc-payments-tech "
 }
+
+// as of now, UK South is unavailable for Application Insights
+variable "appinsights_location" {
+  type = "string"
+  default = "West Europe"
+  description = "Location for Application Insights"
+}
+
+variable "application_type" {
+  type = "string"
+  default = "Web"
+  description = "Type of Application Insights (Web/Other)"
+}


### PR DESCRIPTION
Sandbox deployment failed - this PR adds the missing vars:
```
Initializing the backend...

Successfully configured the backend "azurerm"! Terraform will automatically
use this backend unless the backend configuration changes.

Error: resource 'azurerm_application_insights.appinsights' config: unknown variable referenced: 'appinsights_location'; define it with a 'variable' block

Error: resource 'azurerm_application_insights.appinsights' config: unknown variable referenced: 'application_type'; define it with a 'variable' block
```