### PR TITLE
DTSPO-6371 - add private endpoint provider to service bus module

### DIFF
--- a/asp.tf
+++ b/asp.tf
@@ -1,5 +1,5 @@
 locals {
-  ase_name = join("-", ["core-compute", var.env])
+  ase_name     = join("-", ["core-compute", var.env])
   asp_capacity = "${var.env == "prod" || var.env == "aat" ? 2 : 1}"
   // I2 in prod like env, I1 everywhere else
   sku_size = "${var.env == "prod" || var.env == "aat" ? "I2" : "I1"}"

--- a/key-vault.tf
+++ b/key-vault.tf
@@ -1,30 +1,30 @@
 module "ccpay-vault" {
-  source = "git@github.com:hmcts/cnp-module-key-vault?ref=master"
-  name = join("-", [var.product, var.env])
-  product = var.product
-  env = var.env
-  tenant_id = var.tenant_id
-  object_id = var.jenkins_AAD_objectId
+  source              = "git@github.com:hmcts/cnp-module-key-vault?ref=master"
+  name                = join("-", [var.product, var.env])
+  product             = var.product
+  env                 = var.env
+  tenant_id           = var.tenant_id
+  object_id           = var.jenkins_AAD_objectId
   resource_group_name = azurerm_resource_group.rg.name
   # group id of dcd_reform_dev_azure
   product_group_name = "dcd_group_fees&pay_v2"
-  common_tags         = var.common_tags
+  common_tags        = var.common_tags
   #aks migration
   managed_identity_object_ids = ["${var.managed_identity_object_id}"]
-  create_managed_identity = true
+  create_managed_identity     = true
 }
 
 module "feesregister-vault" {
-  source = "git@github.com:hmcts/cnp-module-key-vault?ref=master"
-  name = join("-", [var.fr_product, var.env])
-  product = var.fr_product
-  env = var.env
-  tenant_id = var.tenant_id
-  object_id = var.jenkins_AAD_objectId
+  source              = "git@github.com:hmcts/cnp-module-key-vault?ref=master"
+  name                = join("-", [var.fr_product, var.env])
+  product             = var.fr_product
+  env                 = var.env
+  tenant_id           = var.tenant_id
+  object_id           = var.jenkins_AAD_objectId
   resource_group_name = azurerm_resource_group.rg.name
   # group id of dcd_reform_dev_azure
   product_group_name = "dcd_group_fees&pay_v2"
-  common_tags         = var.common_tags
+  common_tags        = var.common_tags
   #aks migration
   managed_identity_object_ids = ["${var.managed_identity_object_id}", "${data.azurerm_user_assigned_identity.ccpay-shared-identity.principal_id}"]
 }

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ provider "azurerm" {
 provider "azurerm" {
   features {}
   skip_provider_registration = true
-  alias                      = "private-endpoint"
+  alias                      = "private_endpoint"
   subscription_id            = var.aks_subscription_id
 }
 

--- a/main.tf
+++ b/main.tf
@@ -2,11 +2,18 @@ provider "azurerm" {
   features {}
 }
 
+provider "azurerm" {
+  features {}
+  skip_provider_registration = true
+  alias                      = "private-endpoint"
+  subscription_id            = var.aks_subscription_id
+}
+
 locals {
   local_tags_ccpay = {
     "Deployment Environment" = var.env
-    "Team Name" = var.team_name
-    "Team Contact" = var.team_contact
+    "Team Name"              = var.team_name
+    "Team Contact"           = var.team_contact
   }
 
   tags = merge(var.common_tags, local.local_tags_ccpay)
@@ -15,5 +22,5 @@ locals {
 resource "azurerm_resource_group" "rg" {
   name     = join("-", [var.product, var.env])
   location = var.location
-  tags = local.tags
+  tags     = local.tags
 }

--- a/servicebus.tf
+++ b/servicebus.tf
@@ -5,7 +5,7 @@ locals {
 
 module "servicebus-namespace" {
   providers = {
-    azurerm.private-endpoint = azurerm.private-endpoint
+    azurerm.private_endpoint = azurerm.private_endpoint
   }
   source              = "git@github.com:hmcts/terraform-module-servicebus-namespace"
   name                = "${var.product}-servicebus-${var.env}"

--- a/servicebus.tf
+++ b/servicebus.tf
@@ -1,9 +1,12 @@
 locals {
   subscription_name = "defaultServiceCallbackSubscription"
-  retry_queue = "serviceCallbackRetryQueue"
+  retry_queue       = "serviceCallbackRetryQueue"
 }
 
 module "servicebus-namespace" {
+  providers = {
+    azurerm.private-endpoint = azurerm.private-endpoint
+  }
   source              = "git@github.com:hmcts/terraform-module-servicebus-namespace"
   name                = "${var.product}-servicebus-${var.env}"
   location            = var.location
@@ -13,34 +16,34 @@ module "servicebus-namespace" {
 }
 
 module "topic" {
-  source                = "git@github.com:hmcts/terraform-module-servicebus-topic"
-  name                  = "serviceCallbackTopic"
-  namespace_name        = module.servicebus-namespace.name
-  resource_group_name   = azurerm_resource_group.rg.name
+  source              = "git@github.com:hmcts/terraform-module-servicebus-topic"
+  name                = "serviceCallbackTopic"
+  namespace_name      = module.servicebus-namespace.name
+  resource_group_name = azurerm_resource_group.rg.name
 }
 
 module "queue" {
-  source                = "git@github.com:hmcts/terraform-module-servicebus-queue"
-  name                  = local.retry_queue
-  namespace_name        = module.servicebus-namespace.name
-  resource_group_name   = azurerm_resource_group.rg.name
+  source              = "git@github.com:hmcts/terraform-module-servicebus-queue"
+  name                = local.retry_queue
+  namespace_name      = module.servicebus-namespace.name
+  resource_group_name = azurerm_resource_group.rg.name
 }
 
 module "subscription" {
-  source                = "git@github.com:hmcts/terraform-module-servicebus-subscription"
-  name                  = local.subscription_name
-  namespace_name        = module.servicebus-namespace.name
-  topic_name            = module.topic.name
-  resource_group_name   = azurerm_resource_group.rg.name
-  max_delivery_count    = "1"
+  source                            = "git@github.com:hmcts/terraform-module-servicebus-subscription"
+  name                              = local.subscription_name
+  namespace_name                    = module.servicebus-namespace.name
+  topic_name                        = module.topic.name
+  resource_group_name               = azurerm_resource_group.rg.name
+  max_delivery_count                = "1"
   forward_dead_lettered_messages_to = module.queue.name
 }
 
 
 
 resource "azurerm_key_vault_secret" "servicebus_primary_connection_string" {
-  name      = "sb-primary-connection-string"
-  value     = module.servicebus-namespace.primary_send_and_listen_connection_string
+  name         = "sb-primary-connection-string"
+  value        = module.servicebus-namespace.primary_send_and_listen_connection_string
   key_vault_id = data.azurerm_key_vault.ccpay_key_vault.id
 }
 

--- a/state.tf
+++ b/state.tf
@@ -10,7 +10,7 @@ terraform {
 }
 
 data "azurerm_subnet" "subnet_a" {
-  name                 = join("-",["core-infra-subnet-0" , var.env])
-  virtual_network_name = join("-",["core-infra-vnet" , var.env])
-  resource_group_name  = join("-",["core-infra" , var.env])
+  name                 = join("-", ["core-infra-subnet-0", var.env])
+  virtual_network_name = join("-", ["core-infra-vnet", var.env])
+  resource_group_name  = join("-", ["core-infra", var.env])
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,5 @@
 variable "product" {
-  type = string
+  type    = string
   default = "ccpay"
 }
 
@@ -13,7 +13,7 @@ variable "env" {
 }
 
 variable "subscription" {
-  type    = string
+  type = string
 }
 
 variable "ilbIp" {}
@@ -30,17 +30,17 @@ variable "common_tags" {
   type = map(string)
 }
 variable "team_name" {
-  type = string
+  type        = string
   description = "Team Name"
-  default = "cc-payments"
+  default     = "cc-payments"
 }
 
 variable "team_contact" {
   default = "#cc-payments-tech "
 }
 variable "application_type" {
-  type = string
-  default = "web"
+  type        = string
+  default     = "web"
   description = "Type of Application Insights (Web/Other)"
 }
 
@@ -54,6 +54,8 @@ variable "managed_identity_object_id" {
 }
 
 variable "fr_product" {
-  type = string
+  type    = string
   default = "fees-register"
 }
+
+variable "aks_subscription_id" {}


### PR DESCRIPTION
JIRA link (if applicable)
[tools.hmcts.net/jira/browse/DTSPO-6371](https://tools.hmcts.net/jira/browse/DTSPO-6371)

Change description
PlatOps have made some changes to the service bus terraform module, mainly around adding the ability to enable private endpoints. We needed to add a Private Endpoint provider to allow for Private endpoints being deployed to a different Subscription to the Service Bus being created.

This change should have no effect on anything currently deployed, but it will allow you to deploy a Service Bus with a Private Endpoint if you add the correct inputs to the module.

More information on that can be found here: [hmcts/terraform-module-servicebus-namespace#usage](https://github.com/hmcts/terraform-module-servicebus-namespace#usage)

Does this PR introduce a breaking change? (check one with "x")

[ ] Yes
[x] No