### PR TITLE
DTSPO-6371 add private endpoint provider for service bus

### DIFF
--- a/servicebus.tf
+++ b/servicebus.tf
@@ -4,6 +4,10 @@ locals {
 }
 
 module "servicebus-namespace" {
+  providers = {
+    azurerm.private-endpoint = azurerm.private-endpoint
+  }
+
   source              = "git@github.com:hmcts/terraform-module-servicebus-namespace"
   name                = "${var.product}-servicebus-${var.env}"
   location            = var.location

--- a/state.tf
+++ b/state.tf
@@ -14,3 +14,10 @@ data "azurerm_subnet" "subnet_a" {
   virtual_network_name = join("-",["core-infra-vnet" , var.env])
   resource_group_name  = join("-",["core-infra" , var.env])
 }
+
+provider "azurerm" {
+  features {}
+  skip_provider_registration = true
+  alias                      = "private-endpoint"
+  subscription_id            = var.aks_subscription_id
+}

--- a/variables.tf
+++ b/variables.tf
@@ -57,3 +57,5 @@ variable "fr_product" {
   type = string
   default = "fees-register"
 }
+
+variable "aks_subscription_id" {}


### PR DESCRIPTION
# JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-6371


### Change description ###
PlatOps have made some changes to the service bus terraform module, mainly around adding the ability to enable private endpoints. We needed to add a Private Endpoint provider to allow for Private endpoints being deployed to a different Subscription to the Service Bus being created. 

This change should have no effect on anything currently deployed, but it will allow you to deploy a Service Bus with a Private Endpoint if you add the correct inputs to the module. 

More information on that can be found here: https://github.com/hmcts/terraform-module-servicebus-namespace#usage


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
